### PR TITLE
Fix: list/search tables fails when DBC.TableSizeV is unavailable (#47)

### DIFF
--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -302,9 +302,16 @@ fn list_tables<W: Write>(
     } else {
         "t.DatabaseName = DATABASE".to_string()
     };
+    let db_clause_simple = if let Some(db) = database {
+        format!("DatabaseName = '{}'", escape_sql_string(db))
+    } else {
+        "DatabaseName = DATABASE".to_string()
+    };
 
-    // Query with size from TableSizeV and owner from CreatorName
-    let sql = format!(
+    // Query with size from TableSizeV and owner from CreatorName.
+    // DBC.TableSizeV is not available on all systems; fall back to a simpler
+    // query (no size/row-count columns) when it is inaccessible.
+    let sql_with_size = format!(
         "SELECT TRIM(t.TableName) AS table_name, t.TableKind, \
          COALESCE(CAST(s.RowCount AS VARCHAR(20)), '') AS RowCount, \
          COALESCE(CAST(s.CurrentPerm AS VARCHAR(20)), '') AS CurrentPerm, \
@@ -321,8 +328,20 @@ fn list_tables<W: Write>(
          ORDER BY t.TableName",
         db_clause
     );
+    let sql_no_size = format!(
+        "SELECT TRIM(TableName) AS table_name, TableKind, \
+         '' AS RowCount, '' AS CurrentPerm, \
+         TRIM(CreatorName) AS Owner \
+         FROM DBC.TablesV \
+         WHERE {} AND TableKind IN ('T', 'O') \
+         ORDER BY TableName",
+        db_clause_simple
+    );
 
-    let result = client.execute(&sql)?;
+    let result = match client.execute(&sql_with_size) {
+        Ok(r) => r,
+        Err(_) => client.execute(&sql_no_size)?,
+    };
 
     let tables: Vec<TableEntry> = result
         .rows

--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -149,7 +149,9 @@ fn search_tables<W: Write>(
         limit.unwrap_or(100)
     };
 
-    let sql = format!(
+    // DBC.TableSizeV is not available on all systems; fall back to a simpler
+    // query (no size/row-count columns) when it is inaccessible.
+    let sql_with_size = format!(
         "SELECT TOP {limit} TRIM(t.DatabaseName) AS db_name, \
          TRIM(t.TableName) AS table_name, t.TableKind, \
          COALESCE(CAST(s.RowCount AS VARCHAR(20)), '') AS RowCount, \
@@ -171,8 +173,30 @@ fn search_tables<W: Write>(
         keyword = escaped_keyword,
         db_filter = db_filter
     );
+    let db_filter_simple = if let Some(db) = database {
+        format!("AND DatabaseName = '{}'", escape_sql_string(db))
+    } else {
+        String::new()
+    };
+    let sql_no_size = format!(
+        "SELECT TOP {limit} TRIM(DatabaseName) AS db_name, \
+         TRIM(TableName) AS table_name, TableKind, \
+         '' AS RowCount, '' AS CurrentPerm, \
+         TRIM(CreatorName) AS Owner \
+         FROM DBC.TablesV \
+         WHERE UPPER(TableName) LIKE UPPER('%{keyword}%') \
+         AND TableKind IN ('T', 'O') \
+         {db_filter} \
+         ORDER BY DatabaseName, TableName",
+        limit = row_limit,
+        keyword = escaped_keyword,
+        db_filter = db_filter_simple
+    );
 
-    let result = client.execute(&sql)?;
+    let result = match client.execute(&sql_with_size) {
+        Ok(r) => r,
+        Err(_) => client.execute(&sql_no_size)?,
+    };
 
     let tables: Vec<TableSearchResult> = result
         .rows

--- a/src/db/client.rs
+++ b/src/db/client.rs
@@ -585,10 +585,15 @@ impl DatabaseClient {
                 query: Some(sql.to_string()),
             }
         } else if error_lower.contains("does not exist") || error_lower.contains("not found") {
-            // Try to extract table name
-            TqError::TableNotFound {
-                table: extract_table_name(sql).unwrap_or_else(|| "unknown".to_string()),
-            }
+            // Extract object name from the error message first (e.g. Teradata 3807:
+            // "Object 'DBC.TableSizeV' does not exist."). Only fall back to parsing
+            // the SQL when the error message contains no quoted name, to avoid
+            // reporting the wrong table (e.g. the first FROM target instead of the
+            // actual missing object).
+            let table = extract_quoted_name_from_error(error)
+                .or_else(|| extract_table_name(sql))
+                .unwrap_or_else(|| "unknown".to_string());
+            TqError::TableNotFound { table }
         } else if error_lower.contains("permission") || error_lower.contains("privilege") {
             TqError::PermissionDenied(clean_error)
         } else {
@@ -713,6 +718,20 @@ fn map_type_name_to_teradata_type(type_name: &str) -> TeradataType {
             TeradataType::Unknown
         }
     }
+}
+
+/// Extract the first single-quoted name from a Teradata error message.
+///
+/// Teradata error 3807 looks like:
+///   `[Error 3807] Object 'DBC.TableSizeV' does not exist.`
+/// We extract the content of the first pair of single quotes so we can
+/// report the actual missing object instead of guessing from the SQL.
+fn extract_quoted_name_from_error(error: &str) -> Option<String> {
+    let start = error.find('\'')?;
+    let rest = &error[start + 1..];
+    let end = rest.find('\'')?;
+    let name = rest[..end].trim();
+    if name.is_empty() { None } else { Some(name.to_string()) }
 }
 
 /// Try to extract table name from SQL for error messages
@@ -1307,6 +1326,25 @@ mod tests {
         assert_eq!(
             extract_error_code("[Error 1234] followed by Error 5678"),
             Some(1234)
+        );
+    }
+
+    #[test]
+    fn test_extract_quoted_name_from_error() {
+        // Teradata 3807: Object 'DBC.TableSizeV' does not exist.
+        assert_eq!(
+            extract_quoted_name_from_error("[Error 3807] Object 'DBC.TableSizeV' does not exist."),
+            Some("DBC.TableSizeV".to_string())
+        );
+        // No single quotes in the message
+        assert_eq!(
+            extract_quoted_name_from_error("Object does not exist"),
+            None
+        );
+        // Empty quoted name
+        assert_eq!(
+            extract_quoted_name_from_error("Object '' does not exist"),
+            None
         );
     }
 }


### PR DESCRIPTION
## Summary

Fixes #47 — `tq list tables` was reporting "Table 'DBC.TablesV' does not exist" even though `DBC.TablesV` clearly works. Two bugs combined to cause this:

- **Wrong object name in error message**: when Teradata returned an error about `DBC.TableSizeV` not existing, the error mapper extracted the table name from the SQL (first `FROM` clause = `DBC.TablesV`) instead of from the Teradata error string itself. Added `extract_quoted_name_from_error()` to read the single-quoted name directly from the error message (e.g. `[Error 3807] Object 'DBC.TableSizeV' does not exist`), falling back to SQL parsing only when the error has no quoted name.

- **Hard failure with no fallback**: `list tables` and `search tables` both JOIN against `DBC.TableSizeV` for storage metrics, but that view is not available on all Teradata systems. Both commands now retry with a simpler query (omitting the size/row-count JOIN) when the full query fails, so they always return table names even without storage info.

Commands already handling this gracefully were left unchanged (`inspect`, `query_helpers`).

## Test plan

- [ ] `tq list tables` returns results when `DBC.TableSizeV` is inaccessible (fallback query used)
- [ ] Error messages for missing objects report the correct object name (from Teradata error string, not SQL)
- [ ] All 1394 unit tests pass
- [ ] Clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)